### PR TITLE
Improve type hints and docblocks for cache middleware

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -6,6 +6,3 @@ parameters:
     - src
     - tests
   level: 6
-  checkGenericClassInNonGenericObjectType: false
-  ignoreErrors:
-    - '#Call to an undefined method .*->getStore\(\)->tags#'

--- a/src/Contracts/KeyResolver.php
+++ b/src/Contracts/KeyResolver.php
@@ -9,7 +9,9 @@ use Illuminate\Http\Request;
 interface KeyResolver
 {
     /**
-     * Devuelve [cacheKey, contextArray] para diagnóstico/observabilidad.
+     * Return [cacheKey, contextArray] for the given request.
+     *
+     * @return array{0:string,1:array<string,string>}
      */
     public function make(Request $request): array;
 }

--- a/src/ResponseCacheServiceProvider.php
+++ b/src/ResponseCacheServiceProvider.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace AngelLeger\ResponseCache;
 
-use Illuminate\Contracts\Http\Kernel as HttpKernel;
 use Illuminate\Routing\Router;
 use Illuminate\Support\ServiceProvider;
 use AngelLeger\ResponseCache\Contracts\KeyResolver;
@@ -24,18 +23,19 @@ class ResponseCacheServiceProvider extends ServiceProvider
         });
     }
 
-    public function boot(Router $router, HttpKernel $kernel): void
+    public function boot(Router $router): void
     {
-        $this->publishes([
-            __DIR__ . '/../config/response_cache.php' => config_path('response_cache.php'),
-        ], 'response-cache-config');
-
-        $router->aliasMiddleware('resp.cache', Http\Middleware\ResponseCache::class);
-
         if ($this->app->runningInConsole()) {
+
+            $this->publishes([
+                __DIR__ . '/../config/response_cache.php' => config_path('response_cache.php'),
+            ], 'response-cache-config');
+
             $this->commands([
                 Console\FlushResponseCache::class,
             ]);
         }
+        
+        $router->aliasMiddleware('resp.cache', Http\Middleware\ResponseCache::class);
     }
 }


### PR DESCRIPTION
Enhanced type hints and docblocks in ResponseCache middleware for better static analysis and clarity. Updated KeyResolver interface docblock to English and improved array type annotations. Refactored ResponseCacheServiceProvider to only inject Router in boot method and adjusted middleware registration logic.