### PR TITLE
Add feature tests for response cache middleware

### DIFF
--- a/tests/Feature/ResponseCacheMiddlewareTest.php
+++ b/tests/Feature/ResponseCacheMiddlewareTest.php
@@ -1,1 +1,47 @@
-<?php // full code from doc ... ?>
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Route;
+use AngelLeger\ResponseCache\Support\ResponseCache as Resp;
+
+it('caches get responses', function () {
+    $calls = 0;
+
+    Route::middleware('resp.cache:ttl=10')->get('/foo', function () use (&$calls) {
+        $calls++;
+        return response('bar')->header('Cache-Control', 'public');
+    });
+
+    $first = $this->get('/foo');
+    expect($first->getContent())->toBe('bar');
+    expect($calls)->toBe(1);
+
+    $second = $this->get('/foo');
+    expect($second->getContent())->toBe('bar');
+    expect($calls)->toBe(1);
+});
+
+it('returns 304 when etag matches', function () {
+    Route::middleware('resp.cache:ttl=10')->get('/etag', function () {
+        return response('etagged')->header('Cache-Control', 'public');
+    });
+
+    $first = $this->get('/etag');
+    $etag = $first->headers->get('ETag');
+
+    $second = $this->withHeaders(['If-None-Match' => $etag])->get('/etag');
+
+    expect($second->getStatusCode())->toBe(304);
+    expect($second->getContent())->toBe('');
+});
+
+it('can invalidate cache by tags', function () {
+    Cache::tags(['a'])->put('foo', 'bar', 60);
+    expect(Cache::tags(['a'])->get('foo'))->toBe('bar');
+
+    Resp::invalidateByTags(['a']);
+
+    expect(Cache::tags(['a'])->get('foo'))->toBeNull();
+});

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,1 +1,7 @@
-<?php // full code from doc ... ?>
+<?php
+
+declare(strict_types=1);
+
+use AngelLeger\ResponseCache\Tests\TestCase;
+
+uses(TestCase::class)->in('Feature');

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,1 +1,22 @@
-<?php // full code from doc ... ?>
+<?php
+
+declare(strict_types=1);
+
+namespace AngelLeger\ResponseCache\Tests;
+
+use AngelLeger\ResponseCache\ResponseCacheServiceProvider;
+use Orchestra\Testbench\TestCase as Orchestra;
+
+abstract class TestCase extends Orchestra
+{
+    protected function getPackageProviders($app): array
+    {
+        return [ResponseCacheServiceProvider::class];
+    }
+
+    protected function defineEnvironment($app): void
+    {
+        // Use array cache store during tests
+        $app['config']->set('cache.default', 'array');
+    }
+}


### PR DESCRIPTION
Implemented feature tests for response caching, ETag handling, and cache invalidation by tags. Added Pest and TestCase setup for consistent test environment using array cache store. Minor whitespace fix in service provider.