### PR TITLE
Fix response cache headers and static analysis

### DIFF
--- a/src/Support/ResponseCache.php
+++ b/src/Support/ResponseCache.php
@@ -43,13 +43,12 @@ final class ResponseCache
     public function clearAll(): void
     {
         $store = Cache::store(config('response_cache.store'));
-        $prefix = config('response_cache.prefix', 'resp_cache:');
 
         // This is a nuclear option - use with caution
         // For Redis, you might want to use SCAN to find keys with prefix
         if (method_exists($store->getStore(), 'flush')) {
             Log::warning('ResponseCache: Clearing entire cache store');
-            $store->flush();
+            $store->getStore()->flush();
         }
     }
 

--- a/tests/Feature/ResponseCacheMiddlewareTest.php
+++ b/tests/Feature/ResponseCacheMiddlewareTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Route;
-use AngelLeger\ResponseCache\Support\ResponseCache as Resp;
+use AngelLeger\ResponseCache\Facades\ResponseCache as Resp;
 use function Pest\Laravel\get;
 use function Pest\Laravel\withHeaders;
 


### PR DESCRIPTION
## Summary
- ensure middleware caches responses with default Laravel headers and generates proper Cache-Control and ETag
- fix cache clearing and facade usage in tests
- satisfy PHPStan static analysis

## Testing
- `composer phpstan`
- `./vendor/bin/pest`


------
https://chatgpt.com/codex/tasks/task_e_68b9de3025f0832fb799fb1e1a206b42